### PR TITLE
Fix header file name to AcpiNames.h

### DIFF
--- a/source/tools/acpinames/anmain.c
+++ b/source/tools/acpinames/anmain.c
@@ -41,7 +41,7 @@
  * POSSIBILITY OF SUCH DAMAGES.
  */
 
-#include "acpinames.h"
+#include "AcpiNames.h"
 #include "actables.h"
 #include "errno.h"
 

--- a/source/tools/acpinames/anstubs.c
+++ b/source/tools/acpinames/anstubs.c
@@ -41,7 +41,7 @@
  * POSSIBILITY OF SUCH DAMAGES.
  */
 
-#include "acpinames.h"
+#include "AcpiNames.h"
 
 #include <acutils.h>
 #include <acevents.h>

--- a/source/tools/acpinames/antables.c
+++ b/source/tools/acpinames/antables.c
@@ -41,7 +41,7 @@
  * POSSIBILITY OF SUCH DAMAGES.
  */
 
-#include "acpinames.h"
+#include "AcpiNames.h"
 
 #define _COMPONENT          ACPI_TOOLS
         ACPI_MODULE_NAME    ("antables")


### PR DESCRIPTION
I've tested the patch on aarch64 qemu (up-to-date Fedora 23 ).
